### PR TITLE
Replace asset to secure_asset for heroku asset serving

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,12 +11,12 @@
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
         <!-- Styles -->
-        <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+        <link rel="stylesheet" href="{{ secure_asset('css/app.css') }}">
 
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.2/css/all.css">
 
         <!-- Scripts -->
-        <script src="{{ asset('js/app.js') }}" defer></script>
+        <script src="{{ secure_asset('js/app.js') }}" defer></script>
     </head>
     <body class="font-sans antialiased">
         <div class="min-h-screen bg-gray-100">


### PR DESCRIPTION
#### What does this PR do?

This pull request fixes Heroku assets requests dropping due to http

#### Description of tasks to be completed

The following are the tasks to be completed  
- Replace `asset()` with `secure_asset()`

#### How should you manually test this?
Go to the app's [url](https://larms.herokuapp.com) it should serve the assets